### PR TITLE
Fix deprecation warning when using Buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ RandomAccessFile.prototype.read = function (offset, length, cb) {
   if (!this.readable) return cb(new Error('File is not readable'))
 
   var self = this
-  var buf = Buffer(length)
+  var buf = new Buffer(length)
 
   if (!length) return cb(null, buf)
   fs.read(this.fd, buf, 0, length, offset, onread)


### PR DESCRIPTION
When using from `torrent-stream` a deprecation warning is shown:

```console
(node:72574) DeprecationWarning: Using Buffer without `new` will soon stop working. Use `new Buffer()`, or preferably `Buffer.from()`, `Buffer.allocUnsafe()` or `Buffer.alloc()` instead.
```

This simply updates the Buffer allocation to use the new `7.x` syntax.